### PR TITLE
Improved uids

### DIFF
--- a/lib/pebblebed/uid.rb
+++ b/lib/pebblebed/uid.rb
@@ -27,7 +27,7 @@ module Pebblebed
     def oid=(value)
       return @oid = nil if value == '' || value.nil?
       raise InvalidUid, "Invalid oid '#{value}'" unless self.class.valid_oid?(value)
-      @oid = (value.strip != "") ? value : nil
+      @oid = (value.strip != "") ? CGI.unescape(value) : nil
     end
 
     def self.raw_parse(string)


### PR DESCRIPTION
- allow anything in oids, assuming that it is GCI escaped.
- barf if the oid has non-GCI escaped slashes
- allow complex `klass`, e.g. post.event.meeting
