### PR TITLE
Add support for base_url/base_url configuration

### DIFF
--- a/lib/pebblebed/config.rb
+++ b/lib/pebblebed/config.rb
@@ -11,6 +11,11 @@ module Pebblebed
     def service(name, options = {})
       Pebblebed.require_service(name, options)
     end
+
+    def base_uri(value)
+      Pebblebed.base_uri = value
+    end
+    alias base_url base_uri
   end
 
   def self.require_service(name, options = {})
@@ -48,13 +53,32 @@ module Pebblebed
       @services.keys
     end
 
+    def base_uri
+      @base_uri
+    end
+    alias base_url base_uri
+
+    def base_uri=(value)
+      @base_uri = value
+    end
+    alias base_url= base_uri=
+
     def version_of(service)
       return 1 unless @services && @services[service.to_sym]
       @services[service.to_sym][:version] || 1
     end
 
     def root_url_for(service, url_opts={})
-      URI("http://#{url_opts[:host] || host}/api/#{service}/v#{version_of(service)}/")
+      URI.join(base_url_for(url_opts), "/api/#{service}/v#{version_of(service)}/")
+    end
+
+    def base_url_for(url_opts)
+      raise RuntimeError, "Please specify only one of host & base_uri" if url_opts[:host] && (url_opts[:base_uri] || url_opts[:base_url])
+      [:base_uri, :base_url].each do |key|
+        return url_opts[key] if url_opts[key]
+      end
+      return "http://#{url_opts[:host]}" if url_opts[:host]
+      base_uri || "http://#{host}"
     end
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -31,4 +31,42 @@ describe Pebblebed do
     Pebblebed.root_url_for(:foobar).to_s.should eq "http://example.org/api/foobar/v2/"
   end
 
+  it "works with pebbles that are exposed via https" do
+    Pebblebed.config do
+      service :checkpoint
+      service :foobar, :version => 2
+    end
+    Pebblebed.base_url = "https://example.org"
+    Pebblebed.root_url_for(:checkpoint).to_s.should eq "https://example.org/api/checkpoint/v1/"
+    Pebblebed.root_url_for(:checkpoint, :base_uri => 'https://checkpoint.dev').to_s.should eq "https://checkpoint.dev/api/checkpoint/v1/"
+    Pebblebed.root_url_for(:foobar).to_s.should eq "https://example.org/api/foobar/v2/"
+  end
+
+  it "allows passed in parameters to take precedence" do
+    Pebblebed.config do
+      service :checkpoint
+      service :foobar, :version => 2
+    end
+    Pebblebed.base_url = "https://example.org"
+    Pebblebed.root_url_for(:checkpoint, :host => 'checkpoint.dev').to_s.should eq "http://checkpoint.dev/api/checkpoint/v1/"
+  end
+
+  it "raises an error if :host and :base_uri are both specified as parameters" do
+    Pebblebed.config do
+      service :checkpoint
+    end
+    -> {Pebblebed.root_url_for(:checkpoint, :base_uri => 'https://checkpoint.dev', :host => 'checkpoint.dev')}.should raise_error RuntimeError
+    -> {Pebblebed.root_url_for(:checkpoint, :base_url => 'https://checkpoint.dev', :host => 'checkpoint.dev')}.should raise_error RuntimeError
+  end
+
+  it "request_uri takes precedence over host" do
+    Pebblebed.config do
+      host "example.net"
+      service :checkpoint
+      service :foobar, :version => 2
+    end
+    Pebblebed.base_url = "https://example.org"
+    Pebblebed.root_url_for(:checkpoint).to_s.should eq "https://example.org/api/checkpoint/v1/"
+    Pebblebed.root_url_for(:checkpoint, :base_uri => 'https://checkpoint.dev').to_s.should eq "https://checkpoint.dev/api/checkpoint/v1/"
+  end
 end


### PR DESCRIPTION
As mentioned in Campfire, we need the ability to customize the host and scheme. To that end I've added a base_uri (aliased as base_url) to the configuration class.
