### PR TITLE
Fix memory leak

### DIFF
--- a/lib/pebblebed/http.rb
+++ b/lib/pebblebed/http.rb
@@ -194,7 +194,7 @@ module Pebblebed
     def self.gc
       now = Time.now.to_i
       Thread.current[:pebblebed_gc_at] ||= now
-      if (now - Thread.current[:pebblebed_gc_at] > 10)
+      if (now - Thread.current[:pebblebed_gc_at] > 60)
         Thread.current[:pebblebed_gc_at] = now
         GC.start
       end
@@ -223,10 +223,6 @@ module Pebblebed
     end
 
     def self.current_easy=(value)
-      if (current = Thread.current[:pebblebed_curb_easy])
-        # Reset old instance
-        current.reset
-      end
       Thread.current[:pebblebed_curb_easy] = value
     end
 

--- a/lib/pebblebed/http.rb
+++ b/lib/pebblebed/http.rb
@@ -191,10 +191,20 @@ module Pebblebed
       response
     end
 
+    def self.gc
+      now = Time.now.to_i
+      Thread.current[:pebblebed_gc_at] ||= now
+      if (now - Thread.current[:pebblebed_gc_at] > 10)
+        Thread.current[:pebblebed_gc_at] = now
+        GC.start
+      end
+    end
+
     def self.do_easy(cache: true, &block)
       with_easy(cache: cache) do |easy|
         yield easy
         response = Response.new(easy.url, easy.header_str, easy.body_str)
+        self.gc
         return handle_http_errors(response)
       end
     end


### PR DESCRIPTION
Curb is not able to clean up after itself when the server is never getting rest and the memory will just grow and grow. GC.start every minute will bring back the memory.

This is of course not ideal, but after days of debugging I still haven't found out what exactly is causing the leak within curb (my c++ skills are limited). In curb the leak starts [here](https://github.com/taf2/curb/blob/5d995345827d0135b03afbff6e333f9f4a1921bb/lib/curl/easy.rb#L67).

Also don't call reset on easy as it will create a new easy instance, and that should only happen if the Http class config options are changed.

