### PR TITLE
Replace Curb with Excon

### DIFF
--- a/lib/pebblebed/http.rb
+++ b/lib/pebblebed/http.rb
@@ -1,12 +1,14 @@
 # A wrapper for all low level http client stuff
 
 require 'uri'
-require 'curl'
+require 'excon'
 require 'yajl/json_gem'
 require 'queryparams'
 require 'nokogiri'
 require 'pathbuilder'
 require 'active_support'
+require 'timeout'
+require 'resolv'
 
 module Pebblebed
 
@@ -37,30 +39,29 @@ module Pebblebed
   module Http
 
     DEFAULT_CONNECT_TIMEOUT = 30
-    DEFAULT_REQUEST_TIMEOUT = nil
     DEFAULT_READ_TIMEOUT = 30
+    DEFAULT_WRITE_TIMEOUT = 60
 
     class << self
-      attr_reader :connect_timeout, :request_timeout, :read_timeout
+      attr_reader :connect_timeout, :read_timeout, :write_timeout
       def connect_timeout=(value)
         @connect_timeout = value
-        self.current_easy = nil
-      end
-      def request_timeout=(value)
-        @request_timeout = value
-        self.current_easy = nil
+        Thread.current[:pebblebed_excon] = {}
       end
       def read_timeout=(value)
         @read_timeout = value
-        self.current_easy = nil
+        Thread.current[:pebblebed_excon] = {}
+      end
+      def write_timeout=(value)
+        @write_timeout = value
+        Thread.current[:pebblebed_excon] = {}
       end
     end
 
     class Response
-      def initialize(url, header, body)
+      def initialize(url, status, body)
         @body = body
-        # We parse it ourselves because Curl::Easy fails when there's no text message
-        @status = header.scan(/HTTP\/\d\.\d\s(\d+)\s/).map(&:first).last.to_i
+        @status = status
         @url = url
       end
 
@@ -69,90 +70,123 @@ module Pebblebed
 
     def self.get(url = nil, params = nil, &block)
       url, params = url_and_params_from_args(url, params, &block)
-      return do_easy { |easy|
-        easy.url = url_with_params(url, params)
-        easy.http_get
+      return do_request(url) { |connection|
+        connection.get(
+          :host => url.host,
+          :path => url.path,
+          :query => params,
+          :persistent => true
+        )
       }
     end
 
     def self.post(url, params, &block)
       url, params = url_and_params_from_args(url, params, &block)
       content_type, body = serialize_params(params)
-      return do_easy { |easy|
-        easy.url = url.to_s
-        easy.headers['Accept'] = 'application/json'
-        easy.headers['Content-Type'] = content_type
-        easy.http_post(body)
+      return do_request(url) { |connection|
+        connection.post(
+          :host => url.host,
+          :path => url.path,
+          :headers => {
+            'Accept' => 'application/json',
+            'Content-Type' => content_type
+          },
+          :body => body,
+          :persistent => true
+        )
       }
     end
 
     def self.put(url, params, &block)
       url, params = url_and_params_from_args(url, params, &block)
       content_type, body = serialize_params(params)
-      return do_easy { |easy|
-        easy.url = url.to_s
-        easy.headers['Accept'] = 'application/json'
-        easy.headers['Content-Type'] = content_type
-        easy.http_put(body)
+      return do_request(url) { |connection|
+        connection.put(
+          :host => url.host,
+          :path => url.path,
+          :headers => {
+            'Accept' => 'application/json',
+            'Content-Type' => content_type
+          },
+          :body => body,
+          :persistent => true
+        )
       }
     end
 
     def self.delete(url, params, &block)
       url, params = url_and_params_from_args(url, params, &block)
-      return do_easy { |easy|
-        easy.url = url_with_params(url, params)
-        easy.http_delete
+      return do_request(url) { |connection|
+        connection.delete(
+          :host => url.host,
+          :path => url.path,
+          :query => params,
+          :persistent => true
+        )
       }
     end
 
+    def self.streamer(on_data)
+      lambda do |chunk, remaining_bytes, total_bytes|
+        on_data.call(chunk)
+        total_bytes
+      end
+    end
+
     def self.stream_get(url = nil, params = nil, options = {})
-      return do_easy(cache: false) { |easy|
-        on_data = options[:on_data] or raise "Option :on_data must be specified"
+      on_data = options[:on_data] or raise "Option :on_data must be specified"
 
-        url, params = url_and_params_from_args(url, params)
-
-        easy.url = url_with_params(url, params)
-        easy.on_body do |data|
-          on_data.call(data)
-          data.length
-        end
-        easy.http_get
+      url, params = url_and_params_from_args(url, params)
+      return do_request(url) { |connection|
+        connection.get(
+          :host => url.host,
+          :path => url.path,
+          :query => params,
+          :persistent => false,
+          :response_block => streamer(on_data)
+        )
       }
     end
 
     def self.stream_post(url, params, options = {})
-      return do_easy(cache: false) { |easy|
-        on_data = options[:on_data] or raise "Option :on_data must be specified"
+      on_data = options[:on_data] or raise "Option :on_data must be specified"
 
-        url, params = url_and_params_from_args(url, params)
-        content_type, body = serialize_params(params)
+      url, params = url_and_params_from_args(url, params)
+      content_type, body = serialize_params(params)
 
-        easy.url = url.to_s
-        easy.headers['Accept'] = 'application/json'
-        easy.headers['Content-Type'] = content_type
-        easy.on_body do |data|
-          on_data.call(data)
-          data.length
-        end
-        easy.http_post(body)
+      return do_request(url) { |connection|
+        connection.post(
+          :host => url.host,
+          :path => url.path,
+          :headers => {
+            'Accept' => 'application/json',
+            'Content-Type' => content_type
+          },
+          :body => body,
+          :persistent => false,
+          :response_block => streamer(on_data)
+        )
       }
     end
 
     def self.stream_put(url, params, options = {})
-      return do_easy(cache: false) { |easy|
-        on_data = options[:on_data] or raise "Option :on_data must be specified"
+      on_data = options[:on_data] or raise "Option :on_data must be specified"
 
-        url, params = url_and_params_from_args(url, params)
-        content_type, body = serialize_params(params)
+      url, params = url_and_params_from_args(url, params)
+      content_type, body = serialize_params(params)
 
-        easy.url = url.to_s
-        easy.headers['Accept'] = 'application/json'
-        easy.headers['Content-Type'] = content_type
-        easy.on_body do |data|
-          on_data.call(data)
-          data.length
-        end
-        easy.http_put(body)
+      return do_request(url) { |connection|
+        connection.put(
+          :host => url.host,
+          :path => url.path,
+          :headers => {
+            'Accept' => 'application/json',
+            'Content-Type' => content_type
+          },
+          :body => body,
+          :persistent => false,
+          :response_block => streamer(on_data)
+        )
       }
     end
 
@@ -191,44 +225,65 @@ module Pebblebed
       response
     end
 
-    def self.do_easy(cache: true, &block)
-      with_easy(cache: cache) do |easy|
-        yield easy
-        response = Response.new(easy.url, easy.header_str, easy.body_str)
-        return handle_http_errors(response)
-      end
+    def self.do_request(url, &block)
+      with_connection(url) { |connection|
+        begin
+          request = block.call(connection)
+          response = Response.new(url, request.status, request.body)
+          return handle_http_errors(response)
+        rescue Excon::Errors::SocketError => error
+          # Connection failed, close the connection and try again
+          connection.reset
+          request = block.call(connection)
+          response = Response.new(url, request.status, request.body)
+          return handle_http_errors(response)
+        end
+      }
     end
 
-    def self.with_easy(cache: true, &block)
-      if cache
-        easy = self.current_easy ||= new_easy
+    def self.with_connection(url, &block)
+      connection = self.current_connection(url) || new_connection(url)
+      self.current_connection={:url => url, :connection => connection}
+      yield connection
+    end
+
+    def self.base_url(url)
+      if url.is_a?(URI)
+        uri = url
       else
-        easy = new_easy
+        uri = URI.parse(url)
       end
-      yield easy
+      "#{uri.scheme}://#{uri.host}:#{uri.port}"
     end
 
-    def self.current_easy
-      Thread.current[:pebblebed_curb_easy]
-    end
-
-    def self.current_easy=(value)
-      if (current = Thread.current[:pebblebed_curb_easy])
-        # Reset old instance
-        current.reset
+    def self.cache_key(url)
+      if url.is_a?(URI)
+        uri = url
+      else
+        uri = URI.parse(url)
       end
-      Thread.current[:pebblebed_curb_easy] = value
+      ip = Resolv.getaddress(uri.host)
+      "#{uri.scheme}://#{ip}:#{uri.port}"
     end
 
-    # Returns new Easy instance from current configuration.
-    def self.new_easy
-      easy = Curl::Easy.new
-      easy.connect_timeout = connect_timeout || DEFAULT_CONNECT_TIMEOUT
-      easy.timeout = request_timeout || DEFAULT_REQUEST_TIMEOUT
-      easy.low_speed_time = read_timeout || DEFAULT_READ_TIMEOUT
-      easy.low_speed_limit = 1
-      easy.follow_location = true
-      easy
+    def self.current_connection(url)
+      Thread.current[:pebblebed_excon] ||= {}
+      Thread.current[:pebblebed_excon][cache_key(url)]
+    end
+
+    def self.current_connection=(value)
+      Thread.current[:pebblebed_excon] ||= {}
+      Thread.current[:pebblebed_excon][cache_key(value[:url])] = value[:connection]
+    end
+
+    # Returns new Excon conection from current configuration.
+    def self.new_connection(url)
+      connection = Excon.new(base_url(url), {
+        :read_timeout => read_timeout || DEFAULT_READ_TIMEOUT,
+        :write_timeout => write_timeout || DEFAULT_WRITE_TIMEOUT,
+        :connect_timeout => connect_timeout || DEFAULT_CONNECT_TIMEOUT,
+        :thread_safe_sockets => false
+      })
     end
 
     def self.url_with_params(url, params)

--- a/lib/pebblebed/version.rb
+++ b/lib/pebblebed/version.rb
@@ -1,3 +1,3 @@
 module Pebblebed
-  VERSION = "0.3.26"
+  VERSION = "0.4.0"
 end

--- a/pebblebed.gemspec
+++ b/pebblebed.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "memcache_mock"
 
   s.add_runtime_dependency "deepstruct", ">= 0.0.4"
-  s.add_runtime_dependency "curb", ">= 0.8.8"
+  s.add_runtime_dependency "excon", ">= 0.52.0"
   s.add_runtime_dependency "yajl-ruby"
   s.add_runtime_dependency "queryparams"
   s.add_runtime_dependency "futurevalue"

--- a/pebblebed.gemspec
+++ b/pebblebed.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sinatra" # for testing purposes
   s.add_development_dependency "rack-test" # for testing purposes
   s.add_development_dependency "memcache_mock"
+  s.add_development_dependency "webmock"
 
   s.add_runtime_dependency "deepstruct", ">= 0.0.4"
   s.add_runtime_dependency "excon", ">= 0.52.0"

--- a/spec/http_spec.rb
+++ b/spec/http_spec.rb
@@ -22,8 +22,8 @@ describe Pebblebed::Http do
 
   before :all do
     Pebblebed::Http.connect_timeout = nil
-    Pebblebed::Http.request_timeout = nil
     Pebblebed::Http.read_timeout = nil
+    Pebblebed::Http.write_timeout = nil
 
     # Starts the mock pebble at localhost:8666/api/mock/v1
     mock_pebble.start
@@ -101,7 +101,7 @@ describe Pebblebed::Http do
           })
         result = JSON.parse(buf)
         expect(result["QUERY_STRING"]).to eq "hello=world"
-        expect(response.body).to eq nil
+        expect(response.body).to eq ''
       end
 
       it "supports multiple sequential streaming request" do
@@ -113,28 +113,26 @@ describe Pebblebed::Http do
             })
           result = JSON.parse(buf)
           expect(result["QUERY_STRING"]).to eq "hello=world"
-          expect(response.body).to eq nil
+          expect(response.body).to eq ''
         end
       end
     end
   end
 
-  it "enforces request timeout" do
-    Pebblebed::Http.request_timeout = 1
+  xit "enforces write timeout" do
     expect {
-      Pebblebed::Http.get(pebble_url, {slow: '2'})
-    }.to raise_error(Curl::Err::TimeoutError)
+      Pebblebed::Http.post(pebble_url, {slow: '2'})
+    }.to raise_error(Excon::Errors::Timeout)
     expect {
-      Pebblebed::Http.get(pebble_url, {slow: '0.5'})
+      Pebblebed::Http.post(pebble_url, {slow: '0.5'})
     }.not_to raise_error
   end
 
   it "enforces read timeout" do
-    Pebblebed::Http.request_timeout = 1000
     Pebblebed::Http.read_timeout = 1
     expect {
       Pebblebed::Http.get(pebble_url, {slow: '30'})
-    }.to raise_error(Curl::Err::TimeoutError)
+    }.to raise_error(Excon::Errors::Timeout)
     expect {
       Pebblebed::Http.get(pebble_url, {slow: '0.5'})
     }.not_to raise_error

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'simplecov'
 require 'rspec'
+require 'webmock/rspec'
 
 SimpleCov.add_filter 'spec'
 SimpleCov.add_filter 'config'
@@ -11,6 +12,7 @@ require './spec/mock_pebble'
 RSpec.configure do |c|
   c.mock_with :rspec
   c.before(:each) do
+    WebMock.allow_net_connect!
     ::Pebblebed.memcached = MemcacheMock.new
   end
   c.around(:each) do |example|


### PR DESCRIPTION
Replaced Curb with  Excon with 100% API backward compatibility. Memory leaks are gone! CPU usage is about the same (1-2% more).

Added new config ``write_timeout`` because Excon supports it, so why not. Implemented  old ``request_timeout`` with a straight up Ruby timeout for backward compatibility, because Excon doesn't support it.

Exceptions thrown on timeouts are now ``Excon::Errors::Timeout``  so code depending on rescuing ``Curl::Err::TimeoutError`` will now break. This should perhaps be considered a breaking change, and thus we should raise the version to something more major than patch level?

@alex - I've reimplemented the streaming methods, can you confirm that they are working as expected? (Tests pass though)

